### PR TITLE
Added setup.py file so one can build a conda package for nbparameterise

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,67 @@
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='nbparameterise',
+
+    # Versions should comply with PEP440.
+    version='0.1',
+
+    description='Choose input values for a notebook, and nbparameterise will run it and render to HTML',
+    long_description=long_description,
+
+    # The project's main homepage.
+    url="https://github.com/ucsd-ccbb/nbparameterise",
+
+    # Author details
+    author='Thomas Kluyver',
+    author_email='thomas@kluyver.me.uk',
+
+    # Choose your license
+    license='MIT',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 3 - Alpha',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+
+        # Pick your license as you wish (should match "license" above)
+        'License :: OSI Approved :: MIT License',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language:: Python:: 3:: Only',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
+
+    # What does your project relate to?
+    keywords='development',
+
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+
+    # List run-time dependencies here.  These will be installed by pip when
+    # your project is installed.
+    install_requires=['nbformat']
+)

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,5 @@ setup(
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed.
-    install_requires=['nbformat']
+    install_requires=['astcheck','astsearch','nbformat']
 )


### PR DESCRIPTION
More and more users (including me) are using the cross-platform package manager conda to install  our software dependencies.  I would like to install nbparameterise using conda.  Fortunately, it is trivial to write a conda recipe that builds a conda-installable package of nbparameterise based on the nbparameterise github repository--BUT a setup.py file in the nbparameterise project is required.  Here's one that works :)  