### PR TITLE
Don't execute notebooks by default when replacing definitions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ Usage:
 
 .. code-block:: python
 
+    import nbclient
     import nbformat
     from nbparameterise import (
         extract_parameters, replace_definitions, parameter_values
@@ -45,5 +46,8 @@ Usage:
     # Update one or more parameters
     params = parameter_values(orig_parameters, stock='GOOG')
 
-    # Make a notebook object with these definitions, and execute it.
+    # Make a notebook object with these definitions
     new_nb = replace_definitions(nb, params)
+
+    # Execute the notebook with the new parameters
+    nbclient.execute(new_nb)

--- a/examples/batch.py
+++ b/examples/batch.py
@@ -2,13 +2,13 @@
 """Example of using nbparameterise API to substitute variables in 'batch mode'
 """
 
-from nbparameterise import extract_parameters, parameter_values, replace_definitions
+from nbclient import execute
 import nbformat
+from nbparameterise import extract_parameters, parameter_values, replace_definitions
 
 stock_names = ['AAPL', 'MSFT', 'GOOG']
 
-with open("Stock display.ipynb") as f:
-    nb = nbformat.read(f, as_version=4)
+nb = nbformat.read("Stock display.ipynb", as_version=4)
 
 orig_parameters = extract_parameters(nb)
 
@@ -17,7 +17,8 @@ for name in stock_names:
 
     # Update the parameters and run the notebook
     params = parameter_values(orig_parameters, stock=name)
-    new_nb = replace_definitions(nb, params, execute=True)
+    new_nb = replace_definitions(nb, params)
+    execute(new_nb)
 
     # Save
     with open("Stock display %s.ipynb" % name, 'w') as f:

--- a/examples/webapp.py
+++ b/examples/webapp.py
@@ -12,8 +12,9 @@ Fibonacci.ipynb as well.
 import os.path
 import sys
 
-import nbformat
+from nbclient import execute
 from nbconvert.exporters import HTMLExporter
+import nbformat
 import tornado.ioloop
 import tornado.web
 
@@ -38,19 +39,16 @@ class SubmissionHandler(tornado.web.RequestHandler):
                 inp = v.with_value(v.type(self.get_argument(v.name)))
             defined.append(inp)
 
-        res = {'path': os.path.dirname(self.application.path)}
-        nb = replace_definitions(
-            self.application.nb, defined, execute=True, execute_resources=res
-        )
-        output, _ = HTMLExporter().from_notebook_node(nb, res)
+        nb = replace_definitions(self.application.nb, defined)
+        nb = execute(nb, cwd=os.path.dirname(self.application.path))
+        output, _ = HTMLExporter().from_notebook_node(nb)
         self.write(output)
 
 
 class NbparameteriseApplication(tornado.web.Application):
     def __init__(self, path):
         self.path = path
-        with open(path) as f:
-            self.nb = nbformat.read(f, as_version=4)
+        self.nb = nbformat.read(path, as_version=4)
         
         basename = os.path.basename(path)
         assert basename.endswith('.ipynb')

--- a/nbparameterise/code.py
+++ b/nbparameterise/code.py
@@ -86,7 +86,7 @@ def parameter_values(params, **kwargs):
             res.append(p)
     return res
 
-def replace_definitions(nb, values, execute=None, execute_resources=None,
+def replace_definitions(nb, values, execute=False, execute_resources=None,
                         lang=None):
     """Return a copy of nb with the first code cell defining the given parameters.
 
@@ -101,14 +101,6 @@ def replace_definitions(nb, values, execute=None, execute_resources=None,
     lang may be used to override the kernel name embedded in the notebook. For
     now, nbparameterise only handles 'python3' and 'python2'.
     """
-    if execute is None:
-        warn(
-            "Default execute=True for replace_definitions will change in a "
-            "future version of nbparameterise. Pass execute=True if you need "
-            "execution.", stacklevel=2
-        )
-        execute = True
-
     nb = copy.deepcopy(nb)
     drv = get_driver_module(nb, override=lang)
     first_code_cell(nb).source = drv.build_definitions(values)


### PR DESCRIPTION
Replacing definitions is usually followed by executing the notebook, but execution is a complex thing - you may want to configure timeouts, choose which kernel to use, handle exceptions, make it async, use a [different package](https://github.com/European-XFEL/princess/) from normal to run it...

So, it's better to encourage people to execute as a separate step in calling code, rather than inside `replace_definitions`. Nbparameterise has already warned since 0.4 (July 2020) that the default would change to `execute=False`, and this PR implements that. One day the `execute` option may go altogether, but I'm not going to rush that.

If you just want to execute a notebook the default way, the [nbclient package](https://pypi.org/project/nbclient/) provides a convenient function:

```python
import nbclient
nb = nbclient.execute(nb, cwd=directory_containing_nb)
```

The examples have been updated to use this.