### PR TITLE
Support for getting comments on assignment line

### DIFF
--- a/nbparameterise/code.py
+++ b/nbparameterise/code.py
@@ -20,7 +20,8 @@ class Parameter(object):
 
     def with_value(self, value):
         """Returns a copy with value set to a new value."""
-        return type(self)(self.name, self.type, value, self.metadata or None)
+        return type(self)(self.name, self.type, value, 
+                          self.comment or None, self.metadata or None)
 
 
 def first_code_cell(nb):

--- a/nbparameterise/code.py
+++ b/nbparameterise/code.py
@@ -5,11 +5,12 @@ import re
 from nbconvert.preprocessors import ExecutePreprocessor
 
 class Parameter(object):
-    def __init__(self, name, vtype, value=None, metadata=None):
+    def __init__(self, name, vtype, value=None, comment=None,  metadata=None):
         self.name = name
         self.type = vtype
         self.value = value
         self.metadata = metadata or {}
+        self.comment = comment
 
     def __repr__(self):
         params = [repr(self.name), self.type.__name__]
@@ -20,6 +21,7 @@ class Parameter(object):
     def with_value(self, value):
         """Returns a copy with value set to a new value."""
         return type(self)(self.name, self.type, value, self.metadata or None)
+
 
 def first_code_cell(nb):
     for cell in nb.cells:

--- a/nbparameterise/code_drivers/python.py
+++ b/nbparameterise/code_drivers/python.py
@@ -21,6 +21,8 @@ def check_list(node):
 def check_fillable_node(node, path):
     if isinstance(node, (ast.Num, ast.Str)):
         return
+    elif isinstance(node, ast.UnaryOp) and isinstance(node.operand, ast.Num):
+        return
     elif (isinstance(node, ast.List) 
           and isinstance(node.ctx, ast.Load) and check_list(node)):
         return

--- a/nbparameterise/code_drivers/python3.py
+++ b/nbparameterise/code_drivers/python3.py
@@ -1,7 +1,12 @@
+  GNU nano 2.3.1                               File: ../../../karabo/extern/lib/python3.4/site-packages/nbparameterise/code_drivers/python3.py                                                                     
+
 import ast
 
 import astcheck
 import astsearch
+
+from io import BytesIO
+import tokenize
 
 from ..code import Parameter
 
@@ -26,21 +31,30 @@ def check_fillable_node(node, path):
 
 definition_pattern = ast.Assign(targets=[ast.Name()], value=check_fillable_node)
 
-def type_and_value(node):
+def type_and_value(node, comments={}):
+    comment = comments.get(node.lineno, None)
     if isinstance(node, ast.Num):
         # int or float
-        return type(node.n), node.n
+        return type(node.n), node.n, comment
     elif isinstance(node, ast.Str):
-        return str, node.s
+        return str, node.s, comment
     elif isinstance(node, ast.List):
         return list, [type_and_value(n)[1] for n in node.elts]
-    return (bool, node.value)
+    return bool, node.value, comment
+
+def extract_comments(tokens):
+    comments = {}
+    for ttype, tstr, rowcol, _, _ in tokens:
+        if ttype == tokenize.COMMENT:
+           comments[rowcol[0]] = tstr
+    return comments
 
 def extract_definitions(cell):
     cell_ast = ast.parse(cell)
+    cell_tokens = tokenize.tokenize(BytesIO(cell.encode('utf-8')).readline)
+    comments = extract_comments(cell_tokens)
     for assign in astsearch.ASTPatternFinder(definition_pattern).scan_ast(cell_ast):
-        yield Parameter(assign.targets[0].id, *type_and_value(assign.value))
+        yield Parameter(assign.targets[0].id, *type_and_value(assign.value, comments))
 
 def build_definitions(inputs):
     return "\n".join("{0.name} = {0.value!r}".format(i) for i in inputs)
-

--- a/nbparameterise/code_drivers/python3.py
+++ b/nbparameterise/code_drivers/python3.py
@@ -8,7 +8,7 @@ from ..code import Parameter
 __all__ = ['extract_definitions', 'build_definitions']
 
 def check_fillable_node(node, path):
-    if isinstance(node, (ast.Num, ast.Str)):
+    if isinstance(node, (ast.Num, ast.Str, ast.List)):
         return
     elif isinstance(node, ast.NameConstant) and (node.value in (True, False)):
         return
@@ -23,6 +23,8 @@ def type_and_value(node):
         return type(node.n), node.n
     elif isinstance(node, ast.Str):
         return str, node.s
+    elif isisntance(node, ast.List):
+        return list, node.s
     return (bool, node.value)
 
 def extract_definitions(cell):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name='nbparameterise',
+    version='1.0xfel',
+    packages=['nbparameterise',],
+    url='',
+    author='Thomas, Kluyver, Steffen Hauf',
+    author_email='steffen.hauf@xfel.eu',
+    description='A modified version of the original supporting lists by T. Kluyver'
+)
+

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='nbparameterise',
     version='1.0xfel',
-    packages=['nbparameterise',],
+    packages=['nbparameterise','nbparameterise/code_drivers'],
     url='',
     author='Thomas, Kluyver, Steffen Hauf',
     author_email='steffen.hauf@xfel.eu',

--- a/tests/sample.ipynb
+++ b/tests/sample.ipynb
@@ -1,65 +1,75 @@
 {
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This should be ignored\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = \"Some text\"\n",
+    "b = 12\n",
+    "b2 = -7\n",
+    "c = 14.0\n",
+    "d = False  # comment:bool\n",
+    "e = [0, 1.0, True, \"text\", [0, 1]]\n",
+    "f = {0: 0, \"item\": True, \"dict\": {0: \"text\"}}  # comment:dict\n",
+    "print(\"This should be ignored\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('Some text', 12, 14.0, False)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a, b, c, d"
+   ]
+  }
+ ],
  "metadata": {
-  "name": "",
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  },
   "parameterise": {
    "c": {
     "display_name": "Sea"
    }
-  },
-  "signature": "sha256:5f8a558659fdb1bb35996653f9268523874b1f2949f2ed792d771372cfb45b37"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
-  {
-   "cells": [
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a = \"Some text\"\n",
-      "b = 12\n",
-      "c = 14.0\n",
-      "d = False\n",
-      "e = [0, 1.0, True, \"text\", [0, 1]]\n",
-      "f = {0: 0, \"item\": True, \"dict\": {0: \"text\"}}\n",
-      "print(\"This should be ignored\")"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "This should be ignored\n"
-       ]
-      }
-     ],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a, b, c, d"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 2,
-       "text": [
-        "('Some text', 12, 14.0, False)"
-       ]
-      }
-     ],
-     "prompt_number": 2
-    }
-   ],
-   "metadata": {}
   }
- ]
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -17,18 +17,22 @@ class BasicTestCase(unittest.TestCase):
         assert self.params == [
             Parameter('a', str, "Some text"),
             Parameter('b', int, 12),
+            Parameter('b2', int, -7),
             Parameter('c', float, 14.0),
             Parameter('d', bool, False),
             Parameter('e', list, [0, 1.0, True, "text", [0, 1]]),
             Parameter('f', dict, {0: 0, "item": True, "dict": {0: "text"}}),
         ]
+        assert self.params[4].comment == '# comment:bool'
+        assert self.params[6].comment == '# comment:dict'
 
     def test_rebuild(self):
         from_form = [
             self.params[0].with_value("New text"),
             self.params[1].with_value(21),
-            self.params[2].with_value(0.25),
-            self.params[3].with_value(True),
+            self.params[2].with_value(-3),
+            self.params[3].with_value(0.25),
+            self.params[4].with_value(True),
         ]
         nb = code.replace_definitions(self.nb, from_form, execute=False)
 
@@ -36,6 +40,7 @@ class BasicTestCase(unittest.TestCase):
         exec(nb.cells[0].source, ns)
         assert ns['a'] == "New text"
         assert ns['b'] == 21
+        assert ns['b2'] == -3
         assert ns['c'] == 0.25
         assert ns['d'] == True
 
@@ -45,10 +50,10 @@ class BasicTestCase(unittest.TestCase):
             c = 12.0
         )
 
-        assert [p.name for p in params] == ['a', 'b', 'c', 'd', 'e', 'f']
+        assert [p.name for p in params] == ['a', 'b', 'b2', 'c', 'd', 'e', 'f']
 
         assert params[0].value == 'New text'
         assert params[1].value == 12
-        assert params[2].value == 12.0
-        assert isinstance(params[2].value, float)
-        assert params[3].value == False
+        assert params[3].value == 12.0
+        assert isinstance(params[3].value, float)
+        assert params[4].value == False


### PR DESCRIPTION
This adds support for reading a single-line comment after the assignment making a parameter:

days = 30  # Show n days of data

The comment is exposed as `param.comment` for the caller to use. nbparameterise does not do anything with the comment content, so it doesn't prescribe any particular format. Human readable descriptions are an obvious use case, but someone could put structured data in comments if they wanted to.