### PR TITLE
Add Ast match of None value params

### DIFF
--- a/nbparameterise/code_drivers/python.py
+++ b/nbparameterise/code_drivers/python.py
@@ -5,6 +5,7 @@ import astsearch
 
 from io import StringIO
 import tokenize
+from types import NoneType
 
 from ..code import Parameter
 
@@ -28,6 +29,8 @@ def check_fillable_node(node, path):
         return
     elif isinstance(node, ast.NameConstant) and (node.value in (True, False)):
         return
+    elif isinstance(node, ast.NameConstant) and (node.value is None):
+        return
     elif isinstance(node, ast.List):
         for n in node.elts:
             check_fillable_node(n, path)
@@ -39,7 +42,7 @@ def check_fillable_node(node, path):
             check_fillable_node(n, path)
         return
     
-    raise astcheck.ASTMismatch(path, node, 'number, string, boolean, list or dict')
+    raise astcheck.ASTMismatch(path, node, 'none, number, string, boolean, list or dict')
 
 definition_pattern = ast.Assign(targets=[ast.Name()], value=check_fillable_node)
 
@@ -54,6 +57,8 @@ def type_and_value(node, comments={}):
         return list, [type_and_value(n)[1] for n in node.elts], comment
     elif isinstance(node, ast.NameConstant) and (node.value in (True, False)):
         return bool, node.value, comment
+    elif isinstance(node, ast.NameConstant) and (node.value is None):
+        return NoneType, node.value, comment
     elif isinstance(node, ast.Dict):
         return dict, {type_and_value(node.keys[i])[1]: type_and_value(node.values[i])[1] for i in range(len(node.keys))}, comment
     elif isinstance(node, ast.UnaryOp):

--- a/tests/sample.ipynb
+++ b/tests/sample.ipynb
@@ -21,6 +21,7 @@
     "d = False  # comment:bool\n",
     "e = [0, 1.0, True, \"text\", [0, 1]]\n",
     "f = {0: 0, \"item\": True, \"dict\": {0: \"text\"}}  # comment:dict\n",
+    "g = None\n",
     "print(\"This should be ignored\")"
    ]
   },

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,5 @@
 import os.path
+from types import NoneType
 import unittest
 
 import nbformat
@@ -22,6 +23,7 @@ class BasicTestCase(unittest.TestCase):
             Parameter('d', bool, False),
             Parameter('e', list, [0, 1.0, True, "text", [0, 1]]),
             Parameter('f', dict, {0: 0, "item": True, "dict": {0: "text"}}),
+            Parameter('g', NoneType, None),
         ]
         assert self.params[4].comment == '# comment:bool'
         assert self.params[6].comment == '# comment:dict'
@@ -53,7 +55,7 @@ class BasicTestCase(unittest.TestCase):
             c = 12.0
         )
 
-        assert [p.name for p in params] == ['a', 'b', 'b2', 'c', 'd', 'e', 'f']
+        assert [p.name for p in params] == ['a', 'b', 'b2', 'c', 'd', 'e', 'f', 'g']
 
         assert params[0].value == 'New text'
         assert params[1].value == 12


### PR DESCRIPTION
`None` value parameters are ignored in `extract_parameters` since there are no AST match rule of it.

This PR adds the support on `None` value parameters.