### PR TITLE
Don't require nbconvert

### DIFF
--- a/nbparameterise/code.py
+++ b/nbparameterise/code.py
@@ -3,7 +3,6 @@ import importlib
 import re
 from warnings import warn
 
-from nbconvert.preprocessors import ExecutePreprocessor
 
 class Parameter(object):
     def __init__(self, name, vtype, value=None, metadata=None, comment=None):
@@ -183,6 +182,7 @@ def replace_definitions(nb, values, execute=False, execute_resources=None,
     cell.source = drv.build_definitions(values, prev_code=cell.source)
     if execute:
         warn("execute=True is deprecated, use nbclient instead", stacklevel=2)
+        from nbconvert.preprocessors import ExecutePreprocessor
         resources = execute_resources or {}
         nb, resources = ExecutePreprocessor().preprocess(nb, resources)
     return nb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 readme = "README.rst"
 dependencies = [
-    "nbconvert",
+    "nbformat",
     "astcheck >=0.3",
 ]
 requires-python = ">=3.8"


### PR DESCRIPTION
Nbconvert is only needed for the `execute=True` option, which was deprecated in version 0.6. Loading nbconvert may be slow, so we don't want to do it when it's not needed.

A future version of nbparameterise will likely remove the `execute=` option entirely. Anyone using it should make a separate call to a package like [nbclient](https://github.com/jupyter/nbclient) or [princess](https://github.com/European-XFEL/princess/) instead.

